### PR TITLE
Introducing string expression to ensure replication_group_id max lenght does not exceed 20 chars

### DIFF
--- a/modules/data-stores/elasticache-redis-cluster/main.tf
+++ b/modules/data-stores/elasticache-redis-cluster/main.tf
@@ -31,7 +31,7 @@ resource "aws_security_group" "redis" {
 }
 
 resource "aws_elasticache_replication_group" "redis_replication_group" {
-  replication_group_id          = "${join("",slice(split("",join("-",list(var.project,var.environment))),0,17))}-rg"
+  replication_group_id          = "${replace(join("-",list(var.project,var.environment,var.replication_group_suffix)),"/(.{0,20})(.*)/","$1")}"
   replication_group_description = "${var.project} ${var.environment} replication group"
   node_type                     = "${var.node_type}"
   number_cache_clusters         = "${var.number_cache_clusters}"

--- a/modules/data-stores/elasticache-redis-cluster/main.tf
+++ b/modules/data-stores/elasticache-redis-cluster/main.tf
@@ -31,7 +31,7 @@ resource "aws_security_group" "redis" {
 }
 
 resource "aws_elasticache_replication_group" "redis_replication_group" {
-  replication_group_id          = "${replace(replace(join("-",list(var.project,var.environment,var.replication_group_id_suffix)),"/(.{0,20})(.*)/","$1"),"/(.*)[-](.*)/","$2")}"
+  replication_group_id          = "${replace(replace(join("-",list(var.project,var.environment,var.replication_group_id_suffix)),"/(.{0,20})(.*)/","$1"),"/[-]*$/","")}"
   replication_group_description = "${var.project} ${var.environment} replication group"
   node_type                     = "${var.node_type}"
   number_cache_clusters         = "${var.number_cache_clusters}"

--- a/modules/data-stores/elasticache-redis-cluster/main.tf
+++ b/modules/data-stores/elasticache-redis-cluster/main.tf
@@ -31,7 +31,7 @@ resource "aws_security_group" "redis" {
 }
 
 resource "aws_elasticache_replication_group" "redis_replication_group" {
-  replication_group_id          = "${var.project}-${var.environment}${var.replication_group_id_suffix}"
+  replication_group_id          = "${join("",slice(split("",join("-",list(var.project,var.environment))),0,17))}-rg"
   replication_group_description = "${var.project} ${var.environment} replication group"
   node_type                     = "${var.node_type}"
   number_cache_clusters         = "${var.number_cache_clusters}"

--- a/modules/data-stores/elasticache-redis-cluster/main.tf
+++ b/modules/data-stores/elasticache-redis-cluster/main.tf
@@ -31,7 +31,7 @@ resource "aws_security_group" "redis" {
 }
 
 resource "aws_elasticache_replication_group" "redis_replication_group" {
-  replication_group_id          = "${replace(replace(join("-",list(var.project,var.environment,var.replication_group_id_suffix)),"/(.{0,20})(.*)/","$1"),"(.*)[-](.*)","$1 $2")}"
+  replication_group_id          = "${replace(replace(join("-",list(var.project,var.environment,var.replication_group_id_suffix)),"/(.{0,20})(.*)/","$1"),"/(.*)[-](.*)/","$2")}"
   replication_group_description = "${var.project} ${var.environment} replication group"
   node_type                     = "${var.node_type}"
   number_cache_clusters         = "${var.number_cache_clusters}"

--- a/modules/data-stores/elasticache-redis-cluster/main.tf
+++ b/modules/data-stores/elasticache-redis-cluster/main.tf
@@ -31,7 +31,7 @@ resource "aws_security_group" "redis" {
 }
 
 resource "aws_elasticache_replication_group" "redis_replication_group" {
-  replication_group_id          = "${replace(join("-",list(var.project,var.environment,var.replication_group_suffix)),"/(.{0,20})(.*)/","$1")}"
+  replication_group_id          = "${replace(join("-",list(var.project,var.environment,var.replication_group_id_suffix)),"/(.{0,20})(.*)/","$1")}"
   replication_group_description = "${var.project} ${var.environment} replication group"
   node_type                     = "${var.node_type}"
   number_cache_clusters         = "${var.number_cache_clusters}"

--- a/modules/data-stores/elasticache-redis-cluster/main.tf
+++ b/modules/data-stores/elasticache-redis-cluster/main.tf
@@ -31,7 +31,7 @@ resource "aws_security_group" "redis" {
 }
 
 resource "aws_elasticache_replication_group" "redis_replication_group" {
-  replication_group_id          = "${replace(join("-",list(var.project,var.environment,var.replication_group_id_suffix)),"/(.{0,20})(.*)/","$1")}"
+  replication_group_id          = "${replace(replace(join("-",list(var.project,var.environment,var.replication_group_id_suffix)),"/(.{0,20})(.*)/","$1"),"(.*)[-](.*)","$1 $2")}"
   replication_group_description = "${var.project} ${var.environment} replication group"
   node_type                     = "${var.node_type}"
   number_cache_clusters         = "${var.number_cache_clusters}"

--- a/modules/data-stores/elasticache-redis-cluster/vars.tf
+++ b/modules/data-stores/elasticache-redis-cluster/vars.tf
@@ -28,6 +28,12 @@ variable "availability_zones" {
  * Optional Variables.
  */
 
+variable "replication_group_id_suffix" { 
+  description = "Suffix for the replication_group_id value." 
+  default = "-rg" 
+}
+
+
 variable "number_cache_clusters" {
   description = "The number of cache clusters this replication group will have. If Multi-AZ is enabled , the value of this parameter must be at least 2. Changing this number will force a new resource"
   default     = "2"

--- a/modules/data-stores/elasticache-redis-cluster/vars.tf
+++ b/modules/data-stores/elasticache-redis-cluster/vars.tf
@@ -28,12 +28,6 @@ variable "availability_zones" {
  * Optional Variables.
  */
 
-variable "replication_group_id_suffix" {
-  description = "Suffix for the replication_group_id value."
-  default = "-rg"
-}
-
-
 variable "number_cache_clusters" {
   description = "The number of cache clusters this replication group will have. If Multi-AZ is enabled , the value of this parameter must be at least 2. Changing this number will force a new resource"
   default     = "2"

--- a/modules/data-stores/elasticache-redis-cluster/vars.tf
+++ b/modules/data-stores/elasticache-redis-cluster/vars.tf
@@ -30,9 +30,8 @@ variable "availability_zones" {
 
 variable "replication_group_id_suffix" { 
   description = "Suffix for the replication_group_id value." 
-  default = "-rg" 
+  default = "rg" 
 }
-
 
 variable "number_cache_clusters" {
   description = "The number of cache clusters this replication group will have. If Multi-AZ is enabled , the value of this parameter must be at least 2. Changing this number will force a new resource"


### PR DESCRIPTION
Hi @zmoog this is the patch I would like to introduce to ensure replication_group_id length doesn't exceed 20 chars, as per AWS resource limit